### PR TITLE
feat: Implement admin approval logic for schedule changes with tests

### DIFF
--- a/src/SARS-Project/app/Http/Controllers/Admin/AdminPersetujuanController.php
+++ b/src/SARS-Project/app/Http/Controllers/Admin/AdminPersetujuanController.php
@@ -174,11 +174,19 @@ class AdminPersetujuanController extends Controller
                 ]);
 
                 // Apply permanent change
+                $day = $cr->proposed_day ?? $schedule->day_of_week;
+                $startTime = $cr->proposed_start_time ?? $schedule->start_time;
+                $endTime = $cr->proposed_end_time ?? $schedule->end_time;
+                
+                list($sessionStart, $sessionDuration) = $this->calculateSessionRange($day, $startTime, $endTime);
+
                 $schedule->update([
-                    'day_of_week' => $cr->proposed_day   ?? $schedule->day_of_week,
-                    'start_time'  => $cr->proposed_start_time ?? $schedule->start_time,
-                    'end_time'    => $cr->proposed_end_time   ?? $schedule->end_time,
+                    'day_of_week' => $day,
+                    'start_time'  => $startTime,
+                    'end_time'    => $endTime,
                     'room_id'     => $cr->proposed_room_id    ?? $schedule->room_id,
+                    'session_start' => $sessionStart,
+                    'session_duration' => $sessionDuration,
                     'effective_from' => $cr->effective_from_date ?? Carbon::now()->toDateString(),
                 ]);
             }
@@ -365,5 +373,82 @@ class AdminPersetujuanController extends Controller
         }
 
         return back()->with('success', 'Pengajuan berhasil ditolak.');
+    }
+
+    /**
+     * Calculate session start and duration from day of week, start time, and end time.
+     */
+    private function calculateSessionRange(string $day, string $startTime, string $endTime): array
+    {
+        $isFriday = (strtoupper($day) === 'JUMAT');
+        $sessionTimes = $isFriday ? [
+            1 => ['07:30', '08:20'],
+            2 => ['08:25', '09:15'],
+            3 => ['09:20', '10:10'],
+            4 => ['10:15', '11:05'],
+            5 => ['13:00', '13:50'],
+            6 => ['13:55', '14:45'],
+            7 => ['15:30', '16:20'],
+            8 => ['16:25', '17:15'],
+            9 => ['18:00', '18:50'],
+            10 => ['18:55', '19:20'],
+            11 => ['19:25', '20:15'],
+        ] : [
+            1 => ['07:30', '08:20'],
+            2 => ['08:25', '09:15'],
+            3 => ['09:20', '10:10'],
+            4 => ['10:15', '11:05'],
+            5 => ['11:10', '12:00'],
+            6 => ['13:00', '13:50'],
+            7 => ['13:55', '14:45'],
+            8 => ['15:30', '16:20'],
+            9 => ['16:25', '17:15'],
+            10 => ['18:00', '18:50'],
+            11 => ['18:55', '19:20'],
+        ];
+
+        // Format start/end times to H:i
+        $start = substr($startTime, 0, 5);
+        $end = substr($endTime, 0, 5);
+
+        $startSession = null;
+        $endSession = null;
+
+        // Try exact match
+        foreach ($sessionTimes as $idx => $range) {
+            if ($range[0] === $start) {
+                $startSession = $idx;
+            }
+            if ($range[1] === $end) {
+                $endSession = $idx;
+            }
+        }
+
+        // Fallback to closest match if not found exactly
+        if ($startSession === null) {
+            $minDiff = null;
+            foreach ($sessionTimes as $idx => $range) {
+                $diff = abs(strtotime($range[0]) - strtotime($start));
+                if ($minDiff === null || $diff < $minDiff) {
+                    $minDiff = $diff;
+                    $startSession = $idx;
+                }
+            }
+        }
+
+        if ($endSession === null) {
+            $minDiff = null;
+            foreach ($sessionTimes as $idx => $range) {
+                $diff = abs(strtotime($range[1]) - strtotime($end));
+                if ($minDiff === null || $diff < $minDiff) {
+                    $minDiff = $diff;
+                    $endSession = $idx;
+                }
+            }
+        }
+
+        $sessionDuration = max(1, $endSession - $startSession + 1);
+
+        return [$startSession, $sessionDuration];
     }
 }

--- a/src/SARS-Project/tests/Feature/AdminApprovalTest.php
+++ b/src/SARS-Project/tests/Feature/AdminApprovalTest.php
@@ -1,0 +1,202 @@
+<?php
+
+use App\Models\Course;
+use App\Models\Room;
+use App\Models\Schedule;
+use App\Models\Semester;
+use App\Models\User;
+use App\Models\Role;
+use App\Models\ChangeRequest;
+use App\Models\Approval;
+use App\Models\ScheduleOverride;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Carbon\Carbon;
+
+uses(RefreshDatabase::class);
+
+// Setup context for testing admin approval
+function setupAdminApprovalContext() {
+    $semester = Semester::create([
+        'name' => 'Semester Ganjil 2026',
+        'academic_year' => '2026/2027',
+        'term' => 'GANJIL',
+        'start_date' => Carbon::today()->format('Y-m-d'),
+        'end_date' => Carbon::today()->addMonths(6)->format('Y-m-d'),
+        'is_active' => true,
+    ]);
+
+    $adminRole = Role::create([
+        'name' => 'Admin',
+        'slug' => 'admin',
+    ]);
+
+    $mahasiswaRole = Role::create([
+        'name' => 'Mahasiswa',
+        'slug' => 'mahasiswa',
+    ]);
+
+    $admin = User::create([
+        'name' => 'Budi Admin',
+        'email' => 'admin@sars.test',
+        'password' => bcrypt('password'),
+        'nim_nip' => 'ADM_BUDI',
+    ]);
+    $admin->roles()->attach($adminRole->id, ['assigned_at' => now(), 'assigned_by' => 1]);
+
+    $student = User::create([
+        'name' => 'Andi Mahasiswa',
+        'email' => 'andi@student.sars.test',
+        'password' => bcrypt('password'),
+        'nim_nip' => 'MHS_ANDI',
+    ]);
+    $student->roles()->attach($mahasiswaRole->id, ['assigned_at' => now(), 'assigned_by' => 1]);
+
+    $room1 = Room::create([
+        'name' => 'Kelas A1',
+        'code' => 'K-A1',
+        'capacity' => 40,
+        'building' => 'Gedung A',
+        'type' => 'KELAS',
+        'is_active' => true,
+    ]);
+
+    $room2 = Room::create([
+        'name' => 'Kelas A2',
+        'code' => 'K-A2',
+        'capacity' => 40,
+        'building' => 'Gedung A',
+        'type' => 'KELAS',
+        'is_active' => true,
+    ]);
+
+    $course = Course::create([
+        'semester_id' => $semester->id,
+        'code' => 'MK-ALPRO',
+        'name' => 'Algoritma Pemrograman',
+        'class_name' => 'A',
+        'credits' => 3,
+        'description' => 'Semester 2',
+    ]);
+
+    // Baseline schedule: Room 1, Monday, 07:30 - 10:10 (Sesi 1-3)
+    $schedule = Schedule::create([
+        'course_id' => $course->id,
+        'room_id' => $room1->id,
+        'semester_id' => $semester->id,
+        'day_of_week' => 'SENIN',
+        'start_time' => '07:30:00',
+        'end_time' => '10:10:00',
+        'session_start' => 1,
+        'session_duration' => 3,
+        'effective_from' => Carbon::today()->format('Y-m-d'),
+        'is_active' => true,
+    ]);
+
+    return compact('semester', 'admin', 'student', 'room1', 'room2', 'course', 'schedule');
+}
+
+it('allows admin to approve a PERMANENT request and updates schedule session ranges', function () {
+    $context = setupAdminApprovalContext();
+
+    // Create a PERMANENT request proposed: Tuesday, 09:20 - 12:00 in Room 2 (Sesi 3-5, duration 3)
+    $cr = ChangeRequest::create([
+        'request_code' => 'CR-PERM-001',
+        'requester_id' => $context['student']->id,
+        'schedule_id' => $context['schedule']->id,
+        'semester_id' => $context['semester']->id,
+        'request_type' => 'PERMANENT',
+        'effective_from_date' => Carbon::today()->addDays(7)->format('Y-m-d'),
+        'proposed_day' => 'SELASA',
+        'proposed_start_time' => '09:20:00',
+        'proposed_end_time' => '12:00:00',
+        'proposed_room_id' => $context['room2']->id,
+        'reason' => 'Alasan pergeseran jadwal kuliah permanen mata kuliah ini.',
+        'status' => 'PENDING_ADMIN',
+    ]);
+
+    $response = $this->actingAs($context['admin'])
+        ->post(route('admin.persetujuan.approve', ['id' => $cr->id]), [
+            'notes' => 'Disetujui, ruangan baru dialokasikan.',
+        ]);
+
+    $response->assertSessionHasNoErrors();
+    $response->assertRedirect();
+
+    // Verify change request status is updated to APPROVED
+    $cr->refresh();
+    expect($cr->status)->toBe('APPROVED');
+
+    // Verify approval record
+    $this->assertDatabaseHas('approvals', [
+        'request_id' => $cr->id,
+        'stage' => 'ADMIN_DECISION',
+        'decision' => 'APPROVED',
+        'notes' => 'Disetujui, ruangan baru dialokasikan.',
+        'actor_id' => $context['admin']->id,
+    ]);
+
+    // Verify original schedule attributes have been permanently updated (including recalculated session_start and session_duration)
+    $schedule = $context['schedule']->refresh();
+    expect($schedule->day_of_week)->toBe('SELASA');
+    expect(substr($schedule->start_time, 0, 5))->toBe('09:20');
+    expect(substr($schedule->end_time, 0, 5))->toBe('12:00');
+    expect($schedule->room_id)->toBe($context['room2']->id);
+    expect($schedule->session_start)->toBe(3); // 09:20 is start of Sesi 3
+    expect($schedule->session_duration)->toBe(3); // 09:20 to 12:00 spans Sesi 3, 4, 5 (duration 3)
+
+    // Verify schedule_history was logged
+    $this->assertDatabaseHas('schedule_history', [
+        'schedule_id' => $schedule->id,
+        'request_id' => $cr->id,
+        'changed_by' => $context['admin']->id,
+    ]);
+});
+
+it('allows admin to approve a TEMPORARY request and creates schedule overrides', function () {
+    $context = setupAdminApprovalContext();
+
+    // Create a TEMPORARY request proposed: Friday (Jumat), 13:00 - 14:45 in Room 2 (Jumat Sesi 5-6, duration 2)
+    $targetDate = Carbon::today()->addDays(2)->format('Y-m-d');
+    $cr = ChangeRequest::create([
+        'request_code' => 'CR-TEMP-002',
+        'requester_id' => $context['student']->id,
+        'schedule_id' => $context['schedule']->id,
+        'semester_id' => $context['semester']->id,
+        'request_type' => 'TEMPORARY',
+        'target_date' => $targetDate,
+        'proposed_day' => 'JUMAT',
+        'proposed_start_time' => '13:00:00',
+        'proposed_end_time' => '14:45:00',
+        'proposed_room_id' => $context['room2']->id,
+        'reason' => 'Alasan pergeseran jadwal kuliah sementara untuk pertemuan minggu ini.',
+        'status' => 'PENDING_ADMIN',
+    ]);
+
+    $response = $this->actingAs($context['admin'])
+        ->post(route('admin.persetujuan.approve', ['id' => $cr->id]), [
+            'notes' => 'Diizinkan untuk minggu ini saja.',
+        ]);
+
+    $response->assertSessionHasNoErrors();
+    $response->assertRedirect();
+
+    $cr->refresh();
+    expect($cr->status)->toBe('APPROVED');
+
+    // Verify schedule overrides entry exists
+    $this->assertDatabaseHas('schedule_overrides', [
+        'schedule_id' => $context['schedule']->id,
+        'request_id' => $cr->id,
+        'room_id' => $context['room2']->id,
+        'new_day_of_week' => 'JUMAT',
+        'new_start_time' => '13:00:00',
+        'new_end_time' => '14:45:00',
+        'is_active' => true,
+    ]);
+
+    // Verify the original schedule remains unchanged
+    $schedule = $context['schedule']->refresh();
+    expect($schedule->day_of_week)->toBe('SENIN');
+    expect(substr($schedule->start_time, 0, 5))->toBe('07:30');
+    expect($schedule->room_id)->toBe($context['room1']->id);
+});

--- a/src/SARS-Project/tests/Feature/MahasiswaRequestSubmissionTest.php
+++ b/src/SARS-Project/tests/Feature/MahasiswaRequestSubmissionTest.php
@@ -1,0 +1,453 @@
+<?php
+
+use App\Models\Course;
+use App\Models\Room;
+use App\Models\Schedule;
+use App\Models\Semester;
+use App\Models\User;
+use App\Models\Role;
+use App\Models\ChangeRequest;
+use App\Models\Notification;
+use App\Models\NotificationRecipient;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Carbon\Carbon;
+
+uses(RefreshDatabase::class);
+
+// Helper to set up base objects for testing
+function setupMahasiswaTestContext() {
+    $semester = Semester::create([
+        'name' => 'Semester Ganjil 2026',
+        'academic_year' => '2026/2027',
+        'term' => 'GANJIL',
+        'start_date' => Carbon::today()->format('Y-m-d'),
+        'end_date' => Carbon::today()->addMonths(6)->format('Y-m-d'),
+        'is_active' => true,
+    ]);
+
+    $mahasiswaRole = Role::create([
+        'name' => 'Mahasiswa',
+        'slug' => 'mahasiswa',
+    ]);
+
+    $aslabRole = Role::create([
+        'name' => 'Aslab',
+        'slug' => 'aslab',
+    ]);
+
+    $student = User::create([
+        'name' => 'Budi Mahasiswa',
+        'email' => 'budi@student.sars.test',
+        'password' => bcrypt('password'),
+        'nim_nip' => 'MHS_BUDI',
+    ]);
+    $student->roles()->attach($mahasiswaRole->id, ['assigned_at' => now(), 'assigned_by' => 1]);
+
+    $aslab1 = User::create([
+        'name' => 'Andi Aslab',
+        'email' => 'andi.aslab@sars.test',
+        'password' => bcrypt('password'),
+        'nim_nip' => 'ASLAB_ANDI',
+    ]);
+    $aslab1->roles()->attach($aslabRole->id, ['assigned_at' => now(), 'assigned_by' => 1]);
+
+    $aslab2 = User::create([
+        'name' => 'Citra Aslab',
+        'email' => 'citra.aslab@sars.test',
+        'password' => bcrypt('password'),
+        'nim_nip' => 'ASLAB_CITRA',
+    ]);
+    $aslab2->roles()->attach($aslabRole->id, ['assigned_at' => now(), 'assigned_by' => 1]);
+
+    $room = Room::create([
+        'name' => 'Lab Komputer 1',
+        'code' => 'LAB-KOM-1',
+        'capacity' => 30,
+        'building' => 'Gedung B',
+        'type' => 'LABORATORIUM',
+        'is_active' => true,
+    ]);
+
+    $course = Course::create([
+        'semester_id' => $semester->id,
+        'code' => 'MK-PWEB',
+        'name' => 'Pemrograman Web',
+        'class_name' => 'A',
+        'credits' => 3,
+        'description' => 'Semester 4',
+    ]);
+
+    $schedule = Schedule::create([
+        'course_id' => $course->id,
+        'room_id' => $room->id,
+        'semester_id' => $semester->id,
+        'day_of_week' => 'SENIN',
+        'start_time' => '07:30:00',
+        'end_time' => '10:10:00',
+        'session_start' => 1,
+        'session_duration' => 3,
+        'effective_from' => Carbon::today()->format('Y-m-d'),
+        'is_active' => true,
+    ]);
+
+    return compact('semester', 'student', 'aslab1', 'aslab2', 'room', 'course', 'schedule');
+}
+
+/*
+|--------------------------------------------------------------------------
+| Security & Authorization Tests
+|--------------------------------------------------------------------------
+*/
+
+it('redirects guest / unauthenticated users to login', function () {
+    $response = $this->post(route('mahasiswa.requests.submit'), [
+        'schedule_id' => 1,
+        'request_type' => 'TEMPORARY',
+        'reason' => 'Alasan request perubahan jadwal',
+    ]);
+
+    $response->assertRedirect(route('login'));
+});
+
+it('prevents non-mahasiswa users from accessing mahasiswa submission routes', function () {
+    $context = setupMahasiswaTestContext();
+    $dosenRole = Role::create([
+        'name' => 'Dosen',
+        'slug' => 'dosen',
+    ]);
+    $lecturer = User::create([
+        'name' => 'Dr. Budi',
+        'email' => 'budi@sars.test',
+        'password' => bcrypt('password'),
+        'nim_nip' => 'DSN_BUDI',
+    ]);
+    $lecturer->roles()->attach($dosenRole->id, ['assigned_at' => now(), 'assigned_by' => 1]);
+
+    $response = $this->actingAs($lecturer)->postJson(route('mahasiswa.requests.submit'), [
+        'schedule_id' => $context['schedule']->id,
+        'request_type' => 'TEMPORARY',
+        'reason' => 'Alasan request perubahan jadwal',
+    ]);
+
+    $response->assertStatus(403);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Input Validation Tests
+|--------------------------------------------------------------------------
+*/
+
+it('requires schedule_id, request_type, and reason', function () {
+    $context = setupMahasiswaTestContext();
+
+    $response = $this->actingAs($context['student'])->post(route('mahasiswa.requests.submit'), []);
+
+    $response->assertSessionHasErrors(['schedule_id', 'request_type', 'reason']);
+});
+
+it('requires target_date when request_type is TEMPORARY', function () {
+    $context = setupMahasiswaTestContext();
+
+    $response = $this->actingAs($context['student'])->post(route('mahasiswa.requests.submit'), [
+        'schedule_id' => $context['schedule']->id,
+        'request_type' => 'TEMPORARY',
+        'reason' => 'Ini adalah alasan request perubahan jadwal yang sangat panjang agar lolos validasi 20 karakter.',
+    ]);
+
+    $response->assertSessionHasErrors(['target_date']);
+});
+
+it('requires effective_from_date when request_type is PERMANENT', function () {
+    $context = setupMahasiswaTestContext();
+
+    $response = $this->actingAs($context['student'])->post(route('mahasiswa.requests.submit'), [
+        'schedule_id' => $context['schedule']->id,
+        'request_type' => 'PERMANENT',
+        'reason' => 'Ini adalah alasan request perubahan jadwal yang sangat panjang agar lolos validasi 20 karakter.',
+    ]);
+
+    $response->assertSessionHasErrors(['effective_from_date']);
+});
+
+it('requires reason to be at least 20 characters', function () {
+    $context = setupMahasiswaTestContext();
+
+    $response = $this->actingAs($context['student'])->post(route('mahasiswa.requests.submit'), [
+        'schedule_id' => $context['schedule']->id,
+        'request_type' => 'TEMPORARY',
+        'target_date' => Carbon::today()->format('Y-m-d'),
+        'reason' => 'Terlalu pendek',
+    ]);
+
+    $response->assertSessionHasErrors(['reason']);
+});
+
+it('validates proposed_end_time is after proposed_start_time', function () {
+    $context = setupMahasiswaTestContext();
+
+    $response = $this->actingAs($context['student'])->post(route('mahasiswa.requests.submit'), [
+        'schedule_id' => $context['schedule']->id,
+        'request_type' => 'TEMPORARY',
+        'target_date' => Carbon::today()->format('Y-m-d'),
+        'proposed_day' => 'SELASA',
+        'proposed_start_time' => '10:00',
+        'proposed_end_time' => '09:00', // Chronologically before start time
+        'reason' => 'Ini adalah alasan request perubahan jadwal yang sangat panjang agar lolos validasi 20 karakter.',
+    ]);
+
+    $response->assertSessionHasErrors(['proposed_end_time']);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Submission Flows (Conflict-Free & Conflict-Detected)
+|--------------------------------------------------------------------------
+*/
+
+it('submits a valid conflict-free TEMPORARY request and notifies lab assistants', function () {
+    $context = setupMahasiswaTestContext();
+
+    $targetDate = Carbon::today()->addDay()->format('Y-m-d');
+    $response = $this->actingAs($context['student'])->post(route('mahasiswa.requests.submit'), [
+        'schedule_id' => $context['schedule']->id,
+        'request_type' => 'TEMPORARY',
+        'target_date' => $targetDate,
+        'proposed_day' => 'SELASA',
+        'proposed_start_time' => '09:20',
+        'proposed_end_time' => '12:00',
+        'proposed_room_id' => $context['room']->id,
+        'reason' => 'Ini adalah alasan request perubahan jadwal yang sangat panjang agar lolos validasi 20 karakter.',
+    ]);
+
+    $response->assertSessionHasNoErrors();
+    $response->assertRedirect();
+
+    // Check DB record
+    $this->assertDatabaseHas('change_requests', [
+        'requester_id' => $context['student']->id,
+        'schedule_id' => $context['schedule']->id,
+        'request_type' => 'TEMPORARY',
+        'proposed_day' => 'SELASA',
+        'proposed_start_time' => '09:20',
+        'proposed_end_time' => '12:00',
+        'proposed_room_id' => $context['room']->id,
+        'status' => 'PENDING_ASLAB',
+        'conflict_checked' => true,
+        'has_conflict' => false,
+    ]);
+
+    $changeRequest = ChangeRequest::latest()->first();
+    expect($changeRequest->target_date->format('Y-m-d'))->toBe($targetDate);
+
+    // Check Notifications created
+    $notifications = Notification::where('request_id', $changeRequest->id)->get();
+    expect($notifications->count())->toBe(2);
+
+    foreach ($notifications as $notification) {
+        expect($notification->triggered_by)->toBe($context['student']->id);
+        expect($notification->type)->toBe('REQUEST_SUBMITTED');
+        expect($notification->title)->toBe('Request Perubahan Jadwal Baru');
+        expect($notification->data_payload)->toBeArray();
+        expect($notification->data_payload['request_code'])->toBe($changeRequest->request_code);
+        expect($notification->data_payload['course_name'])->toBe($context['course']->name);
+        expect($notification->data_payload['new_day'])->toBe('SELASA');
+    }
+
+    // Verify both Aslab users received their respective notifications
+    $this->assertDatabaseHas('notification_recipients', [
+        'notification_id' => $notifications[0]->id,
+        'recipient_id' => $context['aslab1']->id,
+        'channel' => 'IN_APP',
+        'is_sent' => true,
+    ]);
+
+    $this->assertDatabaseHas('notification_recipients', [
+        'notification_id' => $notifications[1]->id,
+        'recipient_id' => $context['aslab2']->id,
+        'channel' => 'IN_APP',
+        'is_sent' => true,
+    ]);
+});
+
+it('detects room conflict and flags has_conflict=true with alternative rooms', function () {
+    $context = setupMahasiswaTestContext();
+
+    // Create a conflicting schedule in the same room on Tuesday 09:20 - 12:00
+    $conflictingCourse = Course::create([
+        'semester_id' => $context['semester']->id,
+        'code' => 'MK-ALPRO',
+        'name' => 'Algoritma Pemrograman',
+        'class_name' => 'B',
+        'credits' => 3,
+        'description' => 'Semester 2',
+    ]);
+
+    $conflictingSchedule = Schedule::create([
+        'course_id' => $conflictingCourse->id,
+        'room_id' => $context['room']->id,
+        'semester_id' => $context['semester']->id,
+        'day_of_week' => 'SELASA',
+        'start_time' => '09:20:00',
+        'end_time' => '12:00:00',
+        'session_start' => 3,
+        'session_duration' => 3,
+        'effective_from' => Carbon::today()->format('Y-m-d'),
+        'is_active' => true,
+    ]);
+
+    // Create an alternative room that is active and free
+    $altRoom = Room::create([
+        'name' => 'Lab Komputer 2',
+        'code' => 'LAB-KOM-2',
+        'capacity' => 30,
+        'building' => 'Gedung B',
+        'type' => 'LABORATORIUM',
+        'is_active' => true,
+    ]);
+
+    $targetDate = Carbon::today()->addDay()->format('Y-m-d');
+    
+    // Submit request to move schedule to Tuesday 09:20 - 12:00 in LAB-KOM-1 (which is now busy)
+    $response = $this->actingAs($context['student'])->post(route('mahasiswa.requests.submit'), [
+        'schedule_id' => $context['schedule']->id,
+        'request_type' => 'TEMPORARY',
+        'target_date' => $targetDate,
+        'proposed_day' => 'SELASA',
+        'proposed_start_time' => '09:20',
+        'proposed_end_time' => '12:00',
+        'proposed_room_id' => $context['room']->id,
+        'reason' => 'Ini adalah alasan request perubahan jadwal yang sangat panjang agar lolos validasi 20 karakter.',
+    ]);
+
+    $response->assertSessionHasNoErrors();
+    $response->assertRedirect();
+
+    // Check DB record: has_conflict must be true
+    $this->assertDatabaseHas('change_requests', [
+        'requester_id' => $context['student']->id,
+        'schedule_id' => $context['schedule']->id,
+        'request_type' => 'TEMPORARY',
+        'has_conflict' => true,
+    ]);
+
+    // Check session has alternatives listing the altRoom
+    $response->assertSessionHas('hasConflict', true);
+    $response->assertSessionHas('alternatives');
+    $alternatives = session('alternatives');
+    expect($alternatives)->toBeArray();
+    expect(count($alternatives))->toBeGreaterThanOrEqual(1);
+    expect($alternatives[0]['room_id'])->toBe($altRoom->id);
+    expect($alternatives[0]['room_code'])->toBe('LAB-KOM-2');
+});
+
+/*
+|--------------------------------------------------------------------------
+| History and Polling Endpoints Tests
+|--------------------------------------------------------------------------
+*/
+
+it('allows mahasiswa to delete their own request history', function () {
+    $context = setupMahasiswaTestContext();
+
+    $cr = ChangeRequest::create([
+        'request_code' => 'CR-TEST-1234',
+        'requester_id' => $context['student']->id,
+        'schedule_id' => $context['schedule']->id,
+        'semester_id' => $context['semester']->id,
+        'request_type' => 'TEMPORARY',
+        'reason' => 'Alasan request perubahan jadwal',
+        'status' => 'PENDING_ASLAB',
+    ]);
+
+    $response = $this->actingAs($context['student'])->delete(route('mahasiswa.requests.delete'), [
+        'ids' => [$cr->id],
+    ]);
+
+    $response->assertSessionHasNoErrors();
+    $response->assertRedirect();
+
+    $this->assertDatabaseMissing('change_requests', [
+        'id' => $cr->id,
+    ]);
+});
+
+it('prevents mahasiswa from deleting another student\'s request history', function () {
+    $context = setupMahasiswaTestContext();
+
+    $otherStudent = User::create([
+        'name' => 'Charlie Mahasiswa',
+        'email' => 'charlie@student.sars.test',
+        'password' => bcrypt('password'),
+        'nim_nip' => 'MHS_CHARLIE',
+    ]);
+    $mahasiswaRole = Role::where('slug', 'mahasiswa')->first();
+    $otherStudent->roles()->attach($mahasiswaRole->id, ['assigned_at' => now(), 'assigned_by' => 1]);
+
+    $cr = ChangeRequest::create([
+        'request_code' => 'CR-TEST-5678',
+        'requester_id' => $otherStudent->id,
+        'schedule_id' => $context['schedule']->id,
+        'semester_id' => $context['semester']->id,
+        'request_type' => 'TEMPORARY',
+        'reason' => 'Alasan request perubahan jadwal',
+        'status' => 'PENDING_ASLAB',
+    ]);
+
+    // Logged in as $context['student'], trying to delete $otherStudent's request
+    $response = $this->actingAs($context['student'])->delete(route('mahasiswa.requests.delete'), [
+        'ids' => [$cr->id],
+    ]);
+
+    // Should return session error warning about invalid delete
+    $response->assertSessionHas('error', 'Tidak ada request yang valid untuk dihapus.');
+    $this->assertDatabaseHas('change_requests', [
+        'id' => $cr->id,
+    ]);
+});
+
+it('returns request list as JSON for live-reload', function () {
+    $context = setupMahasiswaTestContext();
+
+    $cr = ChangeRequest::create([
+        'request_code' => 'CR-TEST-9999',
+        'requester_id' => $context['student']->id,
+        'schedule_id' => $context['schedule']->id,
+        'semester_id' => $context['semester']->id,
+        'request_type' => 'TEMPORARY',
+        'reason' => 'Alasan request perubahan jadwal',
+        'status' => 'PENDING_ASLAB',
+    ]);
+
+    $response = $this->actingAs($context['student'])->getJson(route('mahasiswa.requests.list'));
+
+    $response->assertStatus(200);
+    $response->assertJsonStructure([
+        'requests' => [
+            'data',
+            'current_page',
+        ],
+    ]);
+});
+
+it('calculates future meeting dates correctly', function () {
+    $context = setupMahasiswaTestContext();
+
+    $response = $this->actingAs($context['student'])->postJson(route('mahasiswa.meetingDates'), [
+        'schedule_id' => $context['schedule']->id,
+    ]);
+
+    $response->assertStatus(200);
+    $response->assertJsonStructure([
+        'dates',
+    ]);
+
+    $dates = $response->json('dates');
+    expect(count($dates))->toBeGreaterThan(0);
+    // The day of week for $context['schedule'] is 'SENIN'.
+    // Verify each returned date is indeed a Monday (dayOfWeek = 1)
+    foreach ($dates as $entry) {
+        $dateObj = Carbon::parse($entry['date']);
+        expect($dateObj->dayOfWeek)->toBe(Carbon::MONDAY);
+    }
+});


### PR DESCRIPTION
This pull request introduces enhancements to the admin approval process for schedule changes, focusing on accurate calculation and storage of session ranges when a schedule is modified. The most significant update is the addition of logic to determine the session start and duration based on the day of the week and class times, ensuring schedule data remains consistent and reliable. Comprehensive feature tests are also added to validate these changes.

**Session calculation & schedule update improvements:**

* Added a private `calculateSessionRange` method in `AdminPersetujuanController.php` to determine the correct session start and duration based on the day, start time, and end time, with special handling for Fridays (`JUMAT`). This method ensures session data aligns with institutional time slots, even if the provided times do not exactly match session boundaries.
* Updated the permanent schedule update logic in `approve()` to use the calculated `session_start` and `session_duration` fields, ensuring these are always set accurately when a change request is approved.

**Testing & validation:**

* Added a new feature test file `AdminApprovalTest.php` that sets up a realistic context and verifies:
  - Permanent requests update the schedule’s session fields as expected.
  - Temporary requests create schedule overrides without altering the original schedule.
  - Approval records and schedule history are logged correctly.