### PR TITLE
feat(schedule): change week rollover day to Saturday

### DIFF
--- a/src/SARS-Project/app/Http/Controllers/Mahasiswa/MahasiswaController.php
+++ b/src/SARS-Project/app/Http/Controllers/Mahasiswa/MahasiswaController.php
@@ -1197,10 +1197,18 @@ class MahasiswaController extends Controller
                 $targetCarbon->copy()->startOfWeek()->addWeek(), // next week
             ];
 
+            $dayOffsets = [
+                'SENIN'  => 2,
+                'SELASA' => 3,
+                'RABU'   => 4,
+                'KAMIS'  => 5,
+                'JUMAT'  => 6,
+            ];
+
             foreach ($weeksToScan as $weekStart) {
                 foreach ($days as $day) {
-                    $dayIndex = array_search($day, $days);
-                    $dayDate = $weekStart->copy()->addDays($dayIndex)->format('Y-m-d');
+                    $offsetDays = $dayOffsets[$day] ?? 0;
+                    $dayDate = $weekStart->copy()->addDays($offsetDays)->format('Y-m-d');
 
                     // Skip only dates that are truly in the past (before today),
                     // not dates before the target date — those are still valid

--- a/src/SARS-Project/app/Providers/AppServiceProvider.php
+++ b/src/SARS-Project/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Carbon\Carbon;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +20,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Carbon::getTranslator()->setMessages('en', ['first_day_of_week' => Carbon::SATURDAY]);
+        Carbon::getTranslator()->setMessages('id', ['first_day_of_week' => Carbon::SATURDAY]);
     }
 }

--- a/src/SARS-Project/resources/js/Pages/Dashboard/Mahasiswa/Requests.jsx
+++ b/src/SARS-Project/resources/js/Pages/Dashboard/Mahasiswa/Requests.jsx
@@ -87,13 +87,13 @@ const formatDateIndo = (dateStr) => {
 
 const getWeekDate = (dayIndex, offset = 0) => {
     const today = new Date();
-    const currentDay = today.getDay(); // 0 = Sunday, 1 = Monday, ...
-    const distanceToMonday = 1 - currentDay;
-    const monday = new Date(today);
-    monday.setDate(today.getDate() + distanceToMonday + (offset * 7));
+    const currentDay = today.getDay(); // 0 = Sunday, 1 = Monday, ..., 6 = Saturday
+    const daysSinceSaturday = (currentDay + 1) % 7;
+    const saturday = new Date(today);
+    saturday.setDate(today.getDate() - daysSinceSaturday + (offset * 7));
     
-    const targetDate = new Date(monday);
-    targetDate.setDate(monday.getDate() + dayIndex);
+    const targetDate = new Date(saturday);
+    targetDate.setDate(saturday.getDate() + dayIndex + 2);
     return targetDate;
 };
 


### PR DESCRIPTION
## Summary
This PR updates the application's schedule week rollover logic to start on **Saturday** instead of Monday. This allows testing schedule change requests, meeting date generation, and room availability explorers over the weekend for the upcoming academic week.

## Motivation & Context
Previously, the week rolled over on Monday, meaning testing on Saturday or Sunday would still treat the weekend as part of the previous week's schedule cycle. By changing the week start day to Saturday, testing on Saturday immediately loads and evaluates the upcoming week's classes (Monday–Friday).

## Key Changes
- **Backend (Laravel / Carbon)**:
  - Configured global Carbon translator messages in `AppServiceProvider.php` for `en` and `id` locales so `first_day_of_week` defaults to `Carbon::SATURDAY`.
  - Updated `recommendSchedules` day offset mapping in `MahasiswaController.php` so candidate dates for `SENIN` through `JUMAT` calculate correctly relative to the Saturday week start.
- **Frontend (React / Inertia)**:
  - Updated `getWeekDate` in `Requests.jsx` to calculate reference dates relative to the most recent Saturday (`daysSinceSaturday = (currentDay + 1) % 7`).

## 🧪 Testing & Verification
- **Automated Tests**: Ran `./vendor/bin/pest tests/Feature` — all 37 feature tests and 183 assertions passed successfully.
- **Manual Verification**: Verified `getWeekDate` calculation and recommendation candidate dates when evaluating schedules over the weekend.